### PR TITLE
fix-regression-when-ignoring-metaschema-paths

### DIFF
--- a/lib/src/main/kotlin/io/github/lbenedetto/inspector/Inspector.kt
+++ b/lib/src/main/kotlin/io/github/lbenedetto/inspector/Inspector.kt
@@ -69,7 +69,7 @@ object Inspector {
         modifiedRequiredPaths.add(path.back())
       } else if (getLastSubPath(path) == "required" && getLastSubPath(path.back()) != "properties") {
         modifiedRequiredPaths.add(path)
-      } else if (path.startsWith("/$")) {
+      } else if (path.startsWith("/$") && getLastSubPath(path.back()) == "") {
         return@forEach // Ignore change
       } else {
         when (operation) {
@@ -77,7 +77,7 @@ object Inspector {
             // Indicates we are changing to a different way of specifying the type of the property
             if (path.matches(anyOfRegex) || path.matches(refRegex)) {
               changedFieldPaths.add(path)
-            } else {
+            } else if (getLastSubPath(path.back()) != $$"$defs") {
               removedFieldPaths.add(path)
             }
           }
@@ -85,7 +85,7 @@ object Inspector {
             // Indicates we are changing to a different way of specifying the type of the property
             if (path.matches(anyOfRegex) || path.matches(refRegex)) {
               changedFieldPaths.add(path)
-            } else {
+            } else if (getLastSubPath(path.back()) != $$"$defs") {
               addedFieldPaths.add(path)
             }
           }

--- a/lib/src/test/kotlin/io/github/lbenedetto/DefsTest.kt
+++ b/lib/src/test/kotlin/io/github/lbenedetto/DefsTest.kt
@@ -3,9 +3,7 @@ package io.github.lbenedetto
 import io.github.lbenedetto.inspector.ChangeType
 import io.github.lbenedetto.inspector.FieldChange
 import io.github.lbenedetto.inspector.Inspector
-import io.github.lbenedetto.inspector.NonNullRequirementChange
 import io.github.lbenedetto.util.PatchDSL.add
-import io.github.lbenedetto.util.PatchDSL.jsonString
 import io.github.lbenedetto.util.PatchDSL.remove
 import io.github.lbenedetto.util.Util
 import io.github.lbenedetto.util.Util.withPatches
@@ -61,7 +59,7 @@ internal class DefsTest : BehaviorSpec({
                     "someProp"
                   ]
                 }""".trimIndent()
-            @Suppress("JsonStandardCompliance")
+            @Suppress("JsonStandardCompliance") // Reported false positive as KTIJ-35303
             val newField = $$"""
                 {
                   "anyOf": [

--- a/lib/src/test/kotlin/io/github/lbenedetto/DefsTest.kt
+++ b/lib/src/test/kotlin/io/github/lbenedetto/DefsTest.kt
@@ -1,0 +1,122 @@
+package io.github.lbenedetto
+
+import io.github.lbenedetto.inspector.ChangeType
+import io.github.lbenedetto.inspector.FieldChange
+import io.github.lbenedetto.inspector.Inspector
+import io.github.lbenedetto.inspector.NonNullRequirementChange
+import io.github.lbenedetto.util.PatchDSL.add
+import io.github.lbenedetto.util.PatchDSL.jsonString
+import io.github.lbenedetto.util.PatchDSL.remove
+import io.github.lbenedetto.util.Util
+import io.github.lbenedetto.util.Util.withPatches
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+
+internal class DefsTest : BehaviorSpec({
+    Given("A schema") {
+        val schemaPath = "withDefs.schema"
+
+        When("All defs and corresponding props are deleted") {
+            val oldSchema = Util.readSchema(schemaPath)
+            val newSchema = oldSchema.withPatches(
+                remove($$"/$defs"),
+                remove("/properties/foo"),
+                remove("/properties/something"),
+            )
+
+            Then("Only property changes should be detected") {
+                val result = Inspector.inspect(oldSchema, newSchema).all()
+                Inspector.inspect(oldSchema, newSchema).all().shouldContainExactlyInAnyOrder(
+                    FieldChange("/properties", "foo", ChangeType.REMOVED),
+                    FieldChange("/properties", "something", ChangeType.REMOVED)
+                )
+            }
+        }
+
+        When("A def and corresponding prop are removed but one def remains") {
+            val oldSchema = Util.readSchema(schemaPath)
+            val newSchema = oldSchema.withPatches(
+                remove($$"/$defs/Foo"),
+                remove("/properties/foo"),
+            )
+
+            Then("Only property changes should be detected") {
+                Inspector.inspect(oldSchema, newSchema).all().shouldContainExactlyInAnyOrder(
+                    FieldChange("/properties", "foo", ChangeType.REMOVED),
+                )
+            }
+        }
+
+        When("A def and corresponding prop are added") {
+            val oldSchema = Util.readSchema(schemaPath)
+            val newDef = """
+                {
+                  "type": "object",
+                  "properties": {
+                    "someProp": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "someProp"
+                  ]
+                }""".trimIndent()
+            @Suppress("JsonStandardCompliance")
+            val newField = $$"""
+                {
+                  "anyOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/$defs/NewDef"
+                    }
+                  ]
+                }""".trimIndent()
+            val newSchema = oldSchema.withPatches(
+                add($$"/$defs/NewDef", newDef),
+                add("/properties/newField", newField)
+            )
+
+            Then("Only property changes should be detected") {
+                Inspector.inspect(oldSchema, newSchema).all().shouldContainExactlyInAnyOrder(
+                    FieldChange("/properties", "newField", ChangeType.ADDED)
+                )
+            }
+        }
+
+        When("A property in a def is added") {
+            val oldSchema = Util.readSchema(schemaPath)
+            val newSchema = oldSchema.withPatches(
+                add(
+                    $$"/$defs/Foo/properties/newField",
+                    """{ "type": ["number", "null"] }"""
+                ),
+            )
+
+            Then("Change should be detected") {
+                Inspector.inspect(oldSchema, newSchema).all().shouldContainExactlyInAnyOrder(
+                    FieldChange($$"/$defs/Foo/properties", "newField", ChangeType.ADDED),
+                )
+            }
+        }
+
+        When("A property in a def is removed") {
+            val oldSchema = Util.readSchema(schemaPath).withPatches(
+                add(
+                    $$"/$defs/Foo/properties/newField",
+                    """{ "type": ["number", "null"] }"""
+                ),
+            )
+            val newSchema = oldSchema.withPatches(
+                remove($$"/$defs/Foo/properties/newField")
+            )
+
+            Then("Change should be detected") {
+                Inspector.inspect(oldSchema, newSchema).all().shouldContainExactlyInAnyOrder(
+                    FieldChange($$"/$defs/Foo/properties", "newField", ChangeType.REMOVED),
+                )
+            }
+        }
+    }
+})

--- a/lib/src/test/resources/withDefs.schema
+++ b/lib/src/test/resources/withDefs.schema
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "Foo": {
+      "type": "object",
+      "properties": {
+        "bar": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "bar"
+      ]
+    },
+    "Something": {
+      "type": "object",
+      "properties": {
+        "stuff": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "stuff"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "foo": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/Foo"
+        }
+      ]
+    },
+    "something": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/Something"
+        }
+      ]
+    },
+    "baz": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "baz"
+  ]
+}


### PR DESCRIPTION
- We only want to fully ignore changes for paths that start with `$` if they are in the root.
- We don't want to report the addition/removal of an object in `$defs` as a field change (it's not a field after all).
- We do want to report changes in fields of $defs.

Added tests to help document the behavior.