### PR TITLE
fix-wrong-report-of-changes

### DIFF
--- a/lib/src/main/kotlin/io/github/lbenedetto/inspector/Change.kt
+++ b/lib/src/main/kotlin/io/github/lbenedetto/inspector/Change.kt
@@ -10,6 +10,10 @@ interface ChangeWithType : Change {
   val changeType: ChangeType
 }
 
+interface ChangeWithField : ChangeWithType {
+  val field: String
+}
+
 private fun Change.withContext(toString: String) = "${this::class.simpleName}: $toString at $path"
 
 data class AnyOfChange(override val path: String, val value: JsonNode, override val changeType: ChangeType) : ChangeWithType {
@@ -20,7 +24,7 @@ data class EnumValueChange(override val path: String, val value: JsonNode, overr
   override fun toString() = withContext("$changeType enum value $value")
 }
 
-data class FieldChange(override val path: String, val field: String, override val changeType: ChangeType) : ChangeWithType {
+data class FieldChange(override val path: String, override val field: String, override val changeType: ChangeType) : ChangeWithField {
   override fun toString() = withContext("$changeType field $field")
 }
 
@@ -28,11 +32,11 @@ data class FieldTypeChange(override val path: String, val oldType: String, val n
   override fun toString() = withContext("Field type changed from $oldType to $newType")
 }
 
-data class NonNullRequirementChange(override val path: String, val field: String, override val changeType: ChangeType) : ChangeWithType {
+data class NonNullRequirementChange(override val path: String, override val field: String, override val changeType: ChangeType) : ChangeWithField {
   override fun toString() = withContext("$changeType non-null requirement for $field")
 }
 
-data class NotAbsentRequirementChange(override val path: String, val field: String, override val changeType: ChangeType) : ChangeWithType {
+data class NotAbsentRequirementChange(override val path: String, override val field: String, override val changeType: ChangeType) : ChangeWithField {
   override fun toString() = withContext("$changeType non-null requirement for $field")
 }
 

--- a/lib/src/main/kotlin/io/github/lbenedetto/validator/Validator.kt
+++ b/lib/src/main/kotlin/io/github/lbenedetto/validator/Validator.kt
@@ -3,6 +3,7 @@ package io.github.lbenedetto.validator
 import com.fasterxml.jackson.databind.JsonNode
 import io.github.lbenedetto.inspector.Change
 import io.github.lbenedetto.inspector.ChangeType
+import io.github.lbenedetto.inspector.ChangeWithField
 import io.github.lbenedetto.inspector.ChangeWithType
 import io.github.lbenedetto.inspector.DetectedChanges
 import io.github.lbenedetto.inspector.FieldChange
@@ -47,7 +48,8 @@ object Validator {
 
   fun ValidationResult.addFieldChanges(fieldChanges: Set<FieldChange>, changesPerPath: Map<String, List<Change>>, config: Config) {
     fieldChanges.forEach { change ->
-      val changesAtPath = changesPerPath[change.path] ?: emptyList()
+        val changesAtPath = (changesPerPath[change.path] ?: emptyList())
+            .filter { it is ChangeWithField && it.field == change.field }
       val hasNonNullRequirement = changesAtPath.any { it is NonNullRequirementChange }
       val hasNotAbsentRequirement = changesAtPath.any { it is NotAbsentRequirementChange }
 

--- a/lib/src/test/kotlin/io/github/lbenedetto/DefsTest.kt
+++ b/lib/src/test/kotlin/io/github/lbenedetto/DefsTest.kt
@@ -23,7 +23,6 @@ internal class DefsTest : BehaviorSpec({
             )
 
             Then("Only property changes should be detected") {
-                val result = Inspector.inspect(oldSchema, newSchema).all()
                 Inspector.inspect(oldSchema, newSchema).all().shouldContainExactlyInAnyOrder(
                     FieldChange("/properties", "foo", ChangeType.REMOVED),
                     FieldChange("/properties", "something", ChangeType.REMOVED)

--- a/lib/src/test/kotlin/io/github/lbenedetto/MultipleChangesTest.kt
+++ b/lib/src/test/kotlin/io/github/lbenedetto/MultipleChangesTest.kt
@@ -1,0 +1,37 @@
+package io.github.lbenedetto
+
+import io.github.lbenedetto.util.Util
+import io.github.lbenedetto.validator.Config
+import io.github.lbenedetto.validator.Validator
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+
+class MultipleChangesTest : BehaviorSpec({
+    Given("A schema") {
+        val oldSchemaPath = "multipleChangesBefore.schema"
+        val newSchemaPath = "multipleChangesAfter.schema"
+
+        When("Multiple changes are made to the schema properties") {
+            val oldSchema = Util.readSchema(oldSchemaPath)
+            val newSchema = Util.readSchema(newSchemaPath)
+
+            Then("Changes should be correctly reported") {
+                val validationResult = Validator.validate(oldSchema, newSchema, Config.defaultConfig())
+                validationResult.safe.shouldContainExactlyInAnyOrder(
+                    "FieldChange: ADDED field optionalProp at /properties as nullable}",
+                    "FieldChange: ADDED field optionalProp at /properties as optional}",
+                    "NonNullRequirementChange: REMOVED non-null requirement for value at /properties",
+                    "NotAbsentRequirementChange: REMOVED non-null requirement for value at /properties"
+                )
+                validationResult.risky shouldBe emptyList()
+                validationResult.fatal.shouldContainExactlyInAnyOrder(
+                    "FieldChange: ADDED field reqProp at /properties as non-null}",
+                    "FieldChange: ADDED field reqProp at /properties as required}",
+                    "NonNullRequirementChange: ADDED non-null requirement for reqProp at /properties",
+                    "NotAbsentRequirementChange: ADDED non-null requirement for reqProp at /properties"
+                )
+            }
+        }
+    }
+})

--- a/lib/src/test/resources/multipleChangesAfter.schema
+++ b/lib/src/test/resources/multipleChangesAfter.schema
@@ -1,0 +1,16 @@
+{
+  "$schema" : "https://json-schema.org/draft/2020-12/schema",
+  "type" : "object",
+  "properties" : {
+    "optionalProp" : {
+      "type" : [ "boolean", "null" ]
+    },
+    "reqProp" : {
+      "type" : "boolean"
+    },
+    "value" : {
+      "type" : [ "boolean", "null" ]
+    }
+  },
+  "required" : [ "reqProp" ]
+}

--- a/lib/src/test/resources/multipleChangesBefore.schema
+++ b/lib/src/test/resources/multipleChangesBefore.schema
@@ -1,0 +1,10 @@
+{
+  "$schema" : "https://json-schema.org/draft/2020-12/schema",
+  "type" : "object",
+  "properties" : {
+    "value" : {
+      "type" : "boolean"
+    }
+  },
+  "required" : [ "value" ]
+}


### PR DESCRIPTION
I found out that if multiple properties are changed at once the tool will report the validation results in the wrong way.
Currently, for the two schemas I'm adding as a test, it will report the changes as (using default config):

- safe:
```
0 = "NonNullRequirementChange: REMOVED non-null requirement for value at /properties"
1 = "NotAbsentRequirementChange: REMOVED non-null requirement for value at /properties"
```
- risky: empty
- fatal:
```
0 = "FieldChange: ADDED field optionalProp at /properties as non-null}"
1 = "FieldChange: ADDED field optionalProp at /properties as required}"
2 = "FieldChange: ADDED field reqProp at /properties as non-null}"
3 = "FieldChange: ADDED field reqProp at /properties as required}"
4 = "NonNullRequirementChange: ADDED non-null requirement for reqProp at /properties"
5 = "NotAbsentRequirementChange: ADDED non-null requirement for reqProp at /properties"
```

The entries for **optionalProp** should be in safe, not fatal.