### PR TITLE
upgrade-language-versions-and-fix-uniqueItems

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="21" />
+    <bytecodeTargetLevel target="25" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.2.10" />
+    <option name="externalSystemId" value="Gradle" />
+    <option name="version" value="2.3.10" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" project-jdk-name="corretto-24 (2)" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_25" project-jdk-name="corretto-24 (2)" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 [versions]
 zjsonpatch = "0.5.0"
 kotest = "6.0.1"
-dokka = "2.0.0"
+dokka = "2.1.0"
 
 [libraries]
 zjsonpatch = { module = "io.github.vishwakarma:zjsonpatch", version.ref = "zjsonpatch" }
@@ -13,6 +13,6 @@ kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.
 kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest" }
 
 [plugins]
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.2.10" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.3.10" }
 dokka-core = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 dokka-javadoc = { id = "org.jetbrains.dokka-javadoc", version.ref = "dokka" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -42,7 +42,7 @@ java {
   withSourcesJar()
 
   toolchain {
-    languageVersion = JavaLanguageVersion.of(21)
+    languageVersion = JavaLanguageVersion.of(25)
   }
 }
 

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -54,7 +54,7 @@ tasks.named<Jar>("javadocJar") {
 
 object ProjectInfo {
   const val GROUP = "io.github.lbenedetto"
-  const val VERSION = "1.0.1"
+  const val VERSION = "1.0.2"
 }
 
 group = ProjectInfo.GROUP

--- a/lib/src/main/kotlin/io/github/lbenedetto/inspector/Inspector.kt
+++ b/lib/src/main/kotlin/io/github/lbenedetto/inspector/Inspector.kt
@@ -71,6 +71,8 @@ object Inspector {
         modifiedRequiredPaths.add(path)
       } else if (path.startsWith("/$") && path.parentSubPath() == "") {
         return@forEach // Ignore change
+      } else if (getLastSubPath(path) == "uniqueItems" && path.parentSubPath() != "properties") {
+        return@forEach // Ignore change
       } else {
         when (operation) {
           Operation.REMOVE -> {

--- a/lib/src/test/kotlin/io/github/lbenedetto/UniqueItemsTest.kt
+++ b/lib/src/test/kotlin/io/github/lbenedetto/UniqueItemsTest.kt
@@ -1,0 +1,29 @@
+package io.github.lbenedetto
+
+import io.github.lbenedetto.inspector.ChangeType
+import io.github.lbenedetto.inspector.FieldChange
+import io.github.lbenedetto.inspector.Inspector
+import io.github.lbenedetto.util.PatchDSL.add
+import io.github.lbenedetto.util.PatchDSL.remove
+import io.github.lbenedetto.util.Util
+import io.github.lbenedetto.util.Util.withPatches
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+
+internal class UniqueItemsTest : BehaviorSpec({
+    Given("A schema without uniqueItems and a schema with uniqueItems") {
+        val oldSchemaPath = "withoutUniqueItems.schema"
+        val newSchemaPath = "withUniqueItems.schema"
+
+        When("The schemas are compared") {
+            val oldSchema = Util.readSchema(oldSchemaPath)
+            val newSchema = Util.readSchema(newSchemaPath)
+
+            Then("Only property changes should be detected") {
+                Inspector.inspect(oldSchema, newSchema).all().shouldContainExactlyInAnyOrder(
+                    FieldChange($$"/$defs/Foo/properties", "uniqueItems", ChangeType.ADDED)
+                )
+            }
+        }
+    }
+})

--- a/lib/src/test/resources/withUniqueItems.schema
+++ b/lib/src/test/resources/withUniqueItems.schema
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "Foo": {
+      "type": "object",
+      "properties": {
+        "Bar": {
+          "type": [
+            "array"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "uniqueItems": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "Bar"
+      ]
+    }
+  }
+}

--- a/lib/src/test/resources/withoutUniqueItems.schema
+++ b/lib/src/test/resources/withoutUniqueItems.schema
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "Foo": {
+      "type": "object",
+      "properties": {
+        "Bar": {
+          "type": [
+            "array"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "Bar"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adding `uniqueItems: true/false` to an array property breaks the tool.
Also upgrading the java/kotlin versions.